### PR TITLE
Drop `org.kde.*` access

### DIFF
--- a/com.hunterwittenborn.Celeste.yml
+++ b/com.hunterwittenborn.Celeste.yml
@@ -21,7 +21,6 @@ finish-args:
   - '--talk-name=com.canonical.AppMenu.Registrar'
   - '--talk-name=com.canonical.indicator.application'
   - '--talk-name=com.canonical.Unity.LauncherEntry'
-  - '--own-name=org.kde.*'
   # Extra libraries that we've bundled with the Flatpak in order to run.
   # '/usr/lib/x86_64-linux-gnu' is exposed by default, but if we specify
   # one we have to specify them all.


### PR DESCRIPTION
Discord needs it because of being on an outdated electron version, the ones above it should be enough https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

See also https://github.com/flathub/flatpak-builder-lint/issues/66