### PR TITLE
Update GNOME runtime to version 47

### DIFF
--- a/com.hunterwittenborn.Celeste.yml
+++ b/com.hunterwittenborn.Celeste.yml
@@ -1,6 +1,6 @@
 app-id: com.hunterwittenborn.Celeste
 runtime: org.gnome.Platform
-runtime-version: "45"
+runtime-version: "46"
 sdk: org.gnome.Sdk
 command: celeste
 finish-args:

--- a/com.hunterwittenborn.Celeste.yml
+++ b/com.hunterwittenborn.Celeste.yml
@@ -1,6 +1,6 @@
 app-id: com.hunterwittenborn.Celeste
 runtime: org.gnome.Platform
-runtime-version: "46"
+runtime-version: "47"
 sdk: org.gnome.Sdk
 command: celeste
 finish-args:


### PR DESCRIPTION
GNOME runtime version 45 has reached EOL.